### PR TITLE
Bugfix: getSegments (conversion PyBK -> RTTM)

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,4 +1,9 @@
-# 1.1
+# 1.1.1
+- Fixed: silences (and short occurrences <1 sec between silences) occurring inside a speaker turn were postponed at the end of the speaker turn (and could be arbitrarily assigned to next speaker)
+- Fixed: make diarization deterministic (random seed is fixed)
+- Tune length of short occurrences to consider as silences (0.3 sec)
+
+# 1.1.0
 - Changed: loading audio file by AudioSegment toolbox. 
 - Changed: mfcc are extracted by python_speech_features toolbox.
 - Fixed windowRate =< maximumKBMWindowRate.
@@ -6,6 +11,7 @@
 - Similarity matrix is calculated by Binary keys and cumulative vectors
 - Removed: unused AHC.
 - Code formated to pep8
+
 # 1.0.3
 - Fixed: diarization failing on short audio when n_speaker > 1
 - Fixed (TBT): diarization returning segfault on machine with a lot of CPU
@@ -27,7 +33,3 @@
 - Diarization service bases on PyBK.
 - Celery connectivity
 - HTTP API
-
-
-
-

--- a/diarization/processing/speakerdiarization.py
+++ b/diarization/processing/speakerdiarization.py
@@ -169,6 +169,8 @@ class SpeakerDiarization:
                     seg[-1][1] += duration
                 elif spklabel and duration > min_duration:
                     seg = np.vstack((seg, [start, duration, spklabel]))
+                else: # Silence or too short segment
+                    continue
                 first = i + 1
         last = np.size(solutionVector, 1)
         start = (first - 1) * frameshift

--- a/diarization/processing/speakerdiarization.py
+++ b/diarization/processing/speakerdiarization.py
@@ -77,6 +77,9 @@ class SpeakerDiarization:
         self.nbIter = 5  # Number of expectation-maximization (EM) iterations
         self.smoothWin = 100  # Size of the likelihood smoothing window in nb of frames
 
+        # Pseudo-randomness
+        self.seed = 0
+
     def compute_feat_Librosa(self, audioFile):
         try:
             if type(audioFile) is not str:
@@ -363,6 +366,7 @@ class SpeakerDiarization:
                     self.sigma,
                     self.percentile,
                     max_speaker if max_speaker is not None else self.maxNrSpeakers,
+                    random_state=self.seed,
                 )
                 + 1
             )

--- a/pyBK/diarizationFunctions.py
+++ b/pyBK/diarizationFunctions.py
@@ -628,6 +628,7 @@ def getSpectralClustering(
     sigma,
     percentile,
     maxNrSpeakers,
+    random_state = None,
 ):
     if number_speaker is None:
         #  Compute affinity matrix.
@@ -652,7 +653,7 @@ def getSpectralClustering(
             affinity,
             n_clusters=k,
             eigen_solver=None,
-            random_state=None,
+            random_state=random_state,
             n_init=25,
             eigen_tol=0.0,
             assign_labels="kmeans",
@@ -668,7 +669,7 @@ def getSpectralClustering(
             affinity,
             n_clusters=number_speaker,
             eigen_solver=None,
-            random_state=None,
+            random_state=random_state,
             n_init=25,
             eigen_tol=0.0,
             assign_labels="kmeans",

--- a/pyBK/diarizationFunctions.py
+++ b/pyBK/diarizationFunctions.py
@@ -639,25 +639,7 @@ def getSpectralClustering(
 
         (eigenvalues, eigenvectors) = compute_sorted_eigenvectors(affinity)
         # Get number of clusters.
-        k = compute_number_of_clusters(eigenvalues, maxNrSpeakers, 1e-2)
-        # Get spectral embeddings.
-        spectral_embeddings = eigenvectors[:, :k]
-
-        # Run K-Means++ on spectral embeddings.
-        # Note: The correct way should be using a K-Means implementation
-        # that supports customized distance measure such as cosine distance.
-        # This implemention from scikit-learn does NOT, which is inconsistent
-        # with the paper.
-
-        bestClusteringID = spectral_clustering(
-            affinity,
-            n_clusters=k,
-            eigen_solver=None,
-            random_state=random_state,
-            n_init=25,
-            eigen_tol=0.0,
-            assign_labels="kmeans",
-        )
+        number_speaker = compute_number_of_clusters(eigenvalues, maxNrSpeakers, 1e-2)
 
     else:
         #  Compute affinity matrix.
@@ -665,15 +647,16 @@ def getSpectralClustering(
 
         # Laplacian calculation
         affinity = sim_enhancement(simMatrix)
-        bestClusteringID = spectral_clustering(
-            affinity,
-            n_clusters=number_speaker,
-            eigen_solver=None,
-            random_state=random_state,
-            n_init=25,
-            eigen_tol=0.0,
-            assign_labels="kmeans",
-        )
+
+    bestClusteringID = spectral_clustering(
+        affinity,
+        n_clusters=number_speaker,
+        eigen_solver=None,
+        random_state=random_state,
+        n_init=25,
+        eigen_tol=0.0,
+        assign_labels="kmeans",
+    )
 
     return bestClusteringID
 


### PR DESCRIPTION
Fix a bug in getSegments, in the accumulation of the duration.
When silences (and short utterances of less than 1 sec) occurred inside a same speaker turn, the accumulated duration of silences (and short utterances) where removed at the end of the speaker turn.